### PR TITLE
Fix variable naming in RGBA functions

### DIFF
--- a/jslib.inc
+++ b/jslib.inc
@@ -180,8 +180,8 @@ stock void RGBToHex(const int rgb[3], char[] hex, int size) {
  * @param hex          Buffer to store result
  * @param size         Buffer size
  */
-stock void RGBAToHex(const int rgba[3], char[] hex, int size) {
-	IntToHex8(RGBAToInt(rgb), hex, size);
+stock void RGBAToHex(const int rgba[4], char[] hex, int size) {
+	IntToHex8(RGBAToInt(rgba), hex, size);
 }
 
 /**
@@ -203,10 +203,10 @@ stock void IntToRGB(int value, int rgb[3]) {
  * @param rgba          Buffer to store results
  */
 stock void IntToRGBA(int value, int rgba[4]) {
-	rgb[0] = ((value >> 24) & 0xFF);
-	rgb[1] = ((value >> 16) & 0xFF);
-	rgb[2] = ((value >>  8) & 0xFF);
-	rgb[3] = ((value      ) & 0xFF);
+	rgba[0] = ((value >> 24) & 0xFF);
+	rgba[1] = ((value >> 16) & 0xFF);
+	rgba[2] = ((value >>  8) & 0xFF);
+	rgba[3] = ((value      ) & 0xFF);
 }
 
 /**
@@ -228,10 +228,10 @@ stock int RGBToInt(const int rgb[3]) {
  * @return              Result of conversion from RGBA to int
  */
 stock int RGBAToInt(const int rgba[4]) {
-	return ((rgb[0] & 0xFF) << 24) |
-	       ((rgb[1] & 0xFF) << 16) |
-	       ((rgb[2] & 0xFF) <<  8) |
-	       ((rgb[3] & 0xFF)      );
+	return ((rgba[0] & 0xFF) << 24) |
+	       ((rgba[1] & 0xFF) << 16) |
+	       ((rgba[2] & 0xFF) <<  8) |
+	       ((rgba[3] & 0xFF)      );
 }
 
 /**


### PR DESCRIPTION
In some RGBA-related functions, `rgba` is misspelled as `rgb`.